### PR TITLE
5 saga

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+REACT_APP_BACKEND_URL="/api"

--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-REACT_APP_BACKEND_URL="/api"

--- a/history.md
+++ b/history.md
@@ -208,7 +208,38 @@ Wrap the `MovieList` and `MovieDetail` components with the toJS HOC.
 
 ## Configure the Backend
 
+### With Proxy
+
+Add the `REACT_APP_BACKEND_URL="/api"` property to your .env.local file in the project root. If the File doesn't exist create it.
+
+Modify your package.json by adding
+
+    "proxy": {
+      "/api": {
+        "target": "http://localhost:8080" // Or wherever your API is located
+      }
+    }
+
+This will forward calls to /api to http://localhost:8080/api
+
+Restart the dev server.
+
+### Without Proxy
+
+!!! Works only if you have your API installed on your local machine.
+
+To install the Backend on your Local get MongoDB
+https://www.mongodb.com/download-center?jmp=nav#community
+
+Clone the API Project from github
+
+    git clone git@github.com:gaquinozh/movie-app-api.git
+
+Follow the installation Steps on the Readme
+https://github.com/gaquinozh/movie-app-api/blob/master/README.md
+
 Add the `REACT_APP_BACKEND_URL="http://localhost:8080/api"` property to your .env.local file in the project root.
+
 Restart the dev server.
 
 ## Redux-Saga

--- a/package.json
+++ b/package.json
@@ -104,5 +104,10 @@
   "devDependencies": {
     "eslint-config-prettier": "^2.9.0",
     "eslint-plugin-prettier": "^2.5.0"
+  },
+  "proxy": {
+    "/api": {
+      "target": "http://localhost:8080"
+    }
   }
 }


### PR DESCRIPTION
- Habe die history um den Backend-Setup erweitert (mit oder ohne Proxy).
- Eine Anleitung für die Lokale Installation des Backends habe ich auch noch hinzugefügt.
- Proxy ist nun default auf http://localhost:8080 drin, kann man auch rückgängig machen wenn du das nicht magst. 
- Die .env habe ich fälschlicherweise mit commitet, ist aber im zweiten Commit wieder Raus. Sorry for that.